### PR TITLE
Added One Light theme

### DIFF
--- a/themes/one-light.xml
+++ b/themes/one-light.xml
@@ -1,41 +1,41 @@
-        <key name="Palette1" modified="2018-06-13 21:01:42" build="161206">
-          <value name="Name" type="string" data="One Light"/>
-          <value name="ExtendColors" type="hex" data="00"/>
-          <value name="ExtendColorIdx" type="hex" data="0b"/>
-          <value name="TextColorIdx" type="hex" data="10"/>
-          <value name="BackColorIdx" type="hex" data="10"/>
-          <value name="PopTextColorIdx" type="hex" data="10"/>
-          <value name="PopBackColorIdx" type="hex" data="10"/>
-          <value name="ColorTable00" type="dword" data="00fafafa"/> <!-- (syntax-bg) -->
-          <value name="ColorTable01" type="dword" data="00a7a1a0"/> <!-- (mono-3) -->
-          <value name="ColorTable02" type="dword" data="004fa150"/> <!-- (hue-4) -->
-          <value name="ColorTable03" type="dword" data="004fa150"/> <!-- (hue-4) -->
-          <value name="ColorTable04" type="dword" data="004312ca"/> <!-- (hue-5-2) -->
-          <value name="ColorTable05" type="dword" data="00a426a6"/> <!-- (hue-3) -->
-          <value name="ColorTable06" type="dword" data="00016898"/> <!-- (hue-6) -->
-          <value name="ColorTable07" type="dword" data="00bfb2ab"/> <!-- (syntax_fg/mono_1) -->
-          <value name="ColorTable08" type="dword" data="00808080"/> <!-- (NO MATCH) DarkGray (Parameters) -->
-          <value name="ColorTable09" type="dword" data="00f27840"/> <!-- (hue-2) -->
-          <value name="ColorTable10" type="dword" data="004fa150"/> <!-- (hue-4) -->
-          <value name="ColorTable11" type="dword" data="00bc8401"/> <!-- (hue-1) -->
-          <value name="ColorTable12" type="dword" data="004956e4"/> <!-- (hue-5) -->
-          <value name="ColorTable13" type="dword" data="007a77f2"/> <!-- (NO MATCH) Magenta -->
-          <value name="ColorTable14" type="dword" data="00016898"/> <!-- (hue-6) -->
-          <value name="ColorTable15" type="dword" data="00ffffff"/> <!-- (NO MATCH) White (Number, Git diff text) -->
-          <value name="ColorTable16" type="dword" data="00000000"/>
-          <value name="ColorTable17" type="dword" data="00800000"/>
-          <value name="ColorTable18" type="dword" data="00008000"/>
-          <value name="ColorTable19" type="dword" data="00808000"/>
-          <value name="ColorTable20" type="dword" data="00000080"/>
-          <value name="ColorTable21" type="dword" data="00800080"/>
-          <value name="ColorTable22" type="dword" data="00008080"/>
-          <value name="ColorTable23" type="dword" data="00c0c0c0"/>
-          <value name="ColorTable24" type="dword" data="00808080"/>
-          <value name="ColorTable25" type="dword" data="00ff0000"/>
-          <value name="ColorTable26" type="dword" data="0000ff00"/>
-          <value name="ColorTable27" type="dword" data="00ffff00"/>
-          <value name="ColorTable28" type="dword" data="000000ff"/>
-          <value name="ColorTable29" type="dword" data="00ff00ff"/>
-          <value name="ColorTable30" type="dword" data="0000ffff"/>
-          <value name="ColorTable31" type="dword" data="00ffffff"/>
-        </key>
+<key name="Palette1" modified="2018-06-14 14:56:16" build="180206">
+					<value name="Name" type="string" data="One Light"/>
+					<value name="ExtendColors" type="hex" data="00"/>
+					<value name="ExtendColorIdx" type="hex" data="10"/>
+					<value name="TextColorIdx" type="hex" data="10"/>
+					<value name="BackColorIdx" type="hex" data="10"/>
+					<value name="PopTextColorIdx" type="hex" data="10"/>
+					<value name="PopBackColorIdx" type="hex" data="10"/>
+					<value name="ColorTable00" type="dword" data="00fafafa"/>
+					<value name="ColorTable01" type="dword" data="000184c1"/>
+					<value name="ColorTable02" type="dword" data="00a7a1a0"/>
+					<value name="ColorTable03" type="dword" data="004fa150"/>
+					<value name="ColorTable04" type="dword" data="004312ca"/>
+					<value name="ColorTable05" type="dword" data="00a426a6"/>
+					<value name="ColorTable06" type="dword" data="00016898"/>
+					<value name="ColorTable07" type="dword" data="00423a38"/>
+					<value name="ColorTable08" type="dword" data="00423a38"/>
+					<value name="ColorTable09" type="dword" data="00ff6e52"/>
+					<value name="ColorTable10" type="dword" data="004956e4"/>
+					<value name="ColorTable11" type="dword" data="00ff6e52"/>
+					<value name="ColorTable12" type="dword" data="004312ca"/>
+					<value name="ColorTable13" type="dword" data="00e6e5e5"/>
+					<value name="ColorTable14" type="dword" data="00bc8401"/>
+					<value name="ColorTable15" type="dword" data="00f27840"/>
+					<value name="ColorTable16" type="dword" data="00000000"/>
+					<value name="ColorTable17" type="dword" data="00800000"/>
+					<value name="ColorTable18" type="dword" data="00008000"/>
+					<value name="ColorTable19" type="dword" data="00808000"/>
+					<value name="ColorTable20" type="dword" data="00000080"/>
+					<value name="ColorTable21" type="dword" data="00800080"/>
+					<value name="ColorTable22" type="dword" data="00008080"/>
+					<value name="ColorTable23" type="dword" data="00c0c0c0"/>
+					<value name="ColorTable24" type="dword" data="00808080"/>
+					<value name="ColorTable25" type="dword" data="00ff0000"/>
+					<value name="ColorTable26" type="dword" data="0000ff00"/>
+					<value name="ColorTable27" type="dword" data="00ffff00"/>
+					<value name="ColorTable28" type="dword" data="000000ff"/>
+					<value name="ColorTable29" type="dword" data="00ff00ff"/>
+					<value name="ColorTable30" type="dword" data="0000ffff"/>
+					<value name="ColorTable31" type="dword" data="00ffffff"/>
+				</key>

--- a/themes/one-light.xml
+++ b/themes/one-light.xml
@@ -1,0 +1,41 @@
+        <key name="Palette1" modified="2018-06-13 21:01:42" build="161206">
+          <value name="Name" type="string" data="One Light"/>
+          <value name="ExtendColors" type="hex" data="00"/>
+          <value name="ExtendColorIdx" type="hex" data="0b"/>
+          <value name="TextColorIdx" type="hex" data="10"/>
+          <value name="BackColorIdx" type="hex" data="10"/>
+          <value name="PopTextColorIdx" type="hex" data="10"/>
+          <value name="PopBackColorIdx" type="hex" data="10"/>
+          <value name="ColorTable00" type="dword" data="00fafafa"/> <!-- (syntax-bg) -->
+          <value name="ColorTable01" type="dword" data="00a7a1a0"/> <!-- (mono-3) -->
+          <value name="ColorTable02" type="dword" data="004fa150"/> <!-- (hue-4) -->
+          <value name="ColorTable03" type="dword" data="004fa150"/> <!-- (hue-4) -->
+          <value name="ColorTable04" type="dword" data="004312ca"/> <!-- (hue-5-2) -->
+          <value name="ColorTable05" type="dword" data="00a426a6"/> <!-- (hue-3) -->
+          <value name="ColorTable06" type="dword" data="00016898"/> <!-- (hue-6) -->
+          <value name="ColorTable07" type="dword" data="00bfb2ab"/> <!-- (syntax_fg/mono_1) -->
+          <value name="ColorTable08" type="dword" data="00808080"/> <!-- (NO MATCH) DarkGray (Parameters) -->
+          <value name="ColorTable09" type="dword" data="00f27840"/> <!-- (hue-2) -->
+          <value name="ColorTable10" type="dword" data="004fa150"/> <!-- (hue-4) -->
+          <value name="ColorTable11" type="dword" data="00bc8401"/> <!-- (hue-1) -->
+          <value name="ColorTable12" type="dword" data="004956e4"/> <!-- (hue-5) -->
+          <value name="ColorTable13" type="dword" data="007a77f2"/> <!-- (NO MATCH) Magenta -->
+          <value name="ColorTable14" type="dword" data="00016898"/> <!-- (hue-6) -->
+          <value name="ColorTable15" type="dword" data="00ffffff"/> <!-- (NO MATCH) White (Number, Git diff text) -->
+          <value name="ColorTable16" type="dword" data="00000000"/>
+          <value name="ColorTable17" type="dword" data="00800000"/>
+          <value name="ColorTable18" type="dword" data="00008000"/>
+          <value name="ColorTable19" type="dword" data="00808000"/>
+          <value name="ColorTable20" type="dword" data="00000080"/>
+          <value name="ColorTable21" type="dword" data="00800080"/>
+          <value name="ColorTable22" type="dword" data="00008080"/>
+          <value name="ColorTable23" type="dword" data="00c0c0c0"/>
+          <value name="ColorTable24" type="dword" data="00808080"/>
+          <value name="ColorTable25" type="dword" data="00ff0000"/>
+          <value name="ColorTable26" type="dword" data="0000ff00"/>
+          <value name="ColorTable27" type="dword" data="00ffff00"/>
+          <value name="ColorTable28" type="dword" data="000000ff"/>
+          <value name="ColorTable29" type="dword" data="00ff00ff"/>
+          <value name="ColorTable30" type="dword" data="0000ffff"/>
+          <value name="ColorTable31" type="dword" data="00ffffff"/>
+        </key>


### PR DESCRIPTION
Added the [Atom One Light](https://github.com/atom/one-light-syntax/) theme.

I highly recommend adding the following to your $profile to closer match the color scheme. 

```powershell
# Set custom colors to closer match One Light syntax
$options = Get-PSReadLineOption
$options.TypeForegroundColor = 'DarkMagenta'
$options.KeywordForegroundColor = 'DarkMagenta'
$options.NumberForegroundColor = 'DarkYellow'
$options.EmphasisBackgroundColor = 'Magenta'
Remove-Variable -Name options

# Custom progress colors (Black on light grey)
$Host.PrivateData.ProgressForegroundColor = 'DarkGray'
$Host.PrivateData.ProgressBackgroundColor = 'Magenta'
```

Some issues that I can't work around (pretty minor):

- $ should be magenta, but is forced to be the same color as the rest of the variable
- Properties when setting a hashtable are blue, should either be red or black
- 'function' is not recognized as a keyword

## Screenshots

PowerShell:
![image](https://user-images.githubusercontent.com/25251577/41441605-303b3720-6fe8-11e8-81ed-2d3d5e1d97d0.png)

PowerShell (with PSReadLine changes from above):
![image](https://user-images.githubusercontent.com/25251577/41441638-5b642934-6fe8-11e8-988b-5e68f705eddc.png)

Atom (reference):
![image](https://user-images.githubusercontent.com/25251577/41441706-a623185e-6fe8-11e8-972f-57c30972cf72.png)

VSCode (reference):
![image](https://user-images.githubusercontent.com/25251577/41441672-7cbe6e82-6fe8-11e8-91ad-488853ba5851.png)


